### PR TITLE
Update JPEGView.ini

### DIFF
--- a/JPEGView/Config/JPEGView.ini
+++ b/JPEGView/Config/JPEGView.ini
@@ -348,7 +348,7 @@ AutoContrastCorrectionAmount=0.5
 
 ; Amount of color correction in the color channels reg, green, blue, cyan, magenta and yellow
 ; The numbers must be between 0.0 (no correction) and 1.0 (total correction towards the gray world model)
-ColorCorrection = "R: 0.2 G: 0.1 B: 0.35 C: 0.1 M: 0.3 Y: 0.15"
+ColorCorrection = R: 0.2 G: 0.1 B: 0.35 C: 0.1 M: 0.3 Y: 0.15
 
 ; Amount of automatic brightness correction
 ; 0 means no brightness correction, 1 means full correction to middle gray. Must be in (0 .. 1)


### PR DESCRIPTION
Remove erroneous quotes around the ColorCorrection setting

When the value is enclosed in quotes, it will not be read correctly, and the program will use the hardcoded defaults instead. These defaults are the same as the defaults in the settings file, so you won't notice any difference unless you alter them.