### PR TITLE
Stop animation/slideshow when opening file

### DIFF
--- a/src/JPEGView/MainDlg.cpp
+++ b/src/JPEGView/MainDlg.cpp
@@ -2007,6 +2007,8 @@ bool CMainDlg::OpenFileWithDialog(bool bFullScreen, bool bAfterStartup) {
 }
 
 void CMainDlg::OpenFile(LPCTSTR sFileName, bool bAfterStartup) {
+	StopMovieMode();
+	StopAnimation();
 	// recreate file list based on image opened
 	Helpers::ESorting eOldSorting = m_pFileList->GetSorting();
 	bool oOldUpcounting = m_pFileList->IsSortedUpcounting();


### PR DESCRIPTION
This fixes a bug where still images in a folder can unintentionally get played like an animation.
To reproduce:
- Open an animated GIF
- Drag and drop a still image from a folder with multiple images into JPEGView

JPEGView will then cycle through all images in the folder at the speed of the animation. To fix this, the animation must be stopped when opening a file.