### PR TITLE
Treat frame durations <= 10 ms as if they were 100 ms

### DIFF
--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -155,7 +155,6 @@ static CJPEGImage* ConvertGDIPlusBitmapToJPEGImage(Gdiplus::Bitmap* pBitmap, int
 			PropertyItem* pPropertyItem = (PropertyItem*)new char[nTagFrameDelaySize];
 			if (pBitmap->GetPropertyItem(PropertyTagFrameDelay, nTagFrameDelaySize, pPropertyItem) == Gdiplus::Ok) {
 				nFrameTimeMs = ((long*)pPropertyItem->value)[nFrameIndex] * 10;
-				if (nFrameTimeMs <= 0) nFrameTimeMs = 100;
 			}
 			delete[] pPropertyItem;
 		}

--- a/src/JPEGView/JPEGImage.h
+++ b/src/JPEGView/JPEGImage.h
@@ -302,7 +302,8 @@ public:
 	int NumberOfFrames() const { return m_nNumberOfFrames; }
 
 	// Gets the frame time in milliseconds for animations (animated GIF)
-	int FrameTimeMs() const { return m_nFrameTimeMs; }
+	// Defaults to 100ms for frame times <=10, to match behavior of web browsers
+	int FrameTimeMs() const { return m_nFrameTimeMs <= 10 ? 100 : m_nFrameTimeMs; }
 
 	// Gets if this image was created by pasting from clipboard
 	bool IsClipboardImage() const { return m_eImageFormat == IF_CLIPBOARD; }


### PR DESCRIPTION
The behavior of JPEGView differs from the major web browsers when displaying animated images with frame durations <= 10.
Currently, JPEGView displays all 0ms GIF frames as 100ms, and all <10ms frames (for other formats) as 10ms. 
Most web browsers display all <=10ms frames as 100ms:
- [Mozilla](https://hg.mozilla.org/mozilla-central/file/tip/image/FrameTimeout.h#l54)
- [Blink](https://chromium.googlesource.com/chromium/blink/+/refs/heads/main/Source/platform/graphics/ImageSource.cpp#116)
- [WebKit](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp#L252-L259)

Some examples that display differently in JPEGView:
0-delay APNG
![orbit](https://user-images.githubusercontent.com/93988953/211190442-c95b5463-53fc-4e7b-8101-04f3a38b54bd.png)
1-delay GIF (centiseconds)
![dancing-dog-1](https://user-images.githubusercontent.com/93988953/211191286-ca0dc5db-f749-4ab9-83ba-c4ac03098cfc.gif)

Some relevant posts:
[The Fastest GIF Does Not Exist](https://www.biphelps.com/blog/The-Fastest-GIF-Does-Not-Exist)
[Animated GIF Minimum Frame Delay Browser Compatibility Study](https://web.archive.org/web/20141218062230/http://nullsleep.tumblr.com/post/16524517190/animated-gif-minimum-frame-delay-browser)
[]()