### PR TITLE
Update strings_ja.txt

### DIFF
--- a/src/JPEGView/Config/strings_ja.txt
+++ b/src/JPEGView/Config/strings_ja.txt
@@ -8,7 +8,7 @@
 //: ISO 639 code: ja
 //: Language: Japanese
 //: Translator(s): Hiroyuki Matenokoji, maboroshin
-//: Last Updated: 2023-02-05
+//: Last Updated: 2023-02-11
 //: Additional Notes:
 //TranslatorURL=https://pc.genkaku.in/
 // 1st Japanese translation : by Hiroyuki Matenokoji. (2015)
@@ -80,7 +80,7 @@ Cannot read from parameter DB file '%s'!	パラメーターファイルを読み
 Cannot read parameter DB file '%s' because it is too large!	パラメーターファイルが大きすぎます。 %s
 Cannot write to parameter DB file '%s'!	パラメーターファイルに書き込めません。 %s
 Click and drag the mouse vertically to correct image tilt.	縦方向にマウスでドラッグし画像の傾きを調整します、
-Clipboard Image	
+Clipboard Image	クリップボードの画像
 Close	閉じる
 Close help text display / Close JPEGView	ヘルプを閉じる / JPEGView の終了
 Color Correction	色補正
@@ -91,7 +91,7 @@ Conflicting entries in Param DB	パラメーターの設定に競合がありま
 Continue rename/copy?	改名/コピーを続けますか？
 Contrast	コントラスト
 Contrast Correction	コントラストの調整
-Copy file path of the image to clipboard	
+Copy file path of the image to clipboard	画像のファイルパスをクリップボードにコピー
 Copy screen to clipboard/ Copy processed full size image to clipboard	画面をクリップボードにコピー/加工したフルサイズ画像をクリップボードにコピー
 Copying parameter DB to file '%s' failed. Reason: %s	ファイル %s へのパラメーターのコピーが失敗しました。原因: %s
 Correct converging lines (perspective correction)	消失点の調整 (遠近法)
@@ -104,7 +104,7 @@ Darken Highlights	ハイライトを暗く
 Date	日付
 Date placeholders use the modification date of the image.	引数の日付は画像の更新日時を使用します。
 Day / Month / Year (as numbers)	日 / 月 / 年 (数字)
-Decoding this format requires the Microsoft Visual C++ Redistributable.	
+Decoding this format requires the Microsoft Visual C++ Redistributable.	この形式をデコードするには Microsoft Visual C++ Redistributable が必要です。
 Deep Shadows	最も暗い部分
 Delete	削除
 Delete current file on disk permanently	表示中の画像ファイルを完全に削除
@@ -154,7 +154,7 @@ Goto next image	次の画像
 Goto previous image	前の画像
 Height	高さ
 Hide histogram	ヒストグラムを非表示
-High quality resampling	
+High quality resampling	高品質表示
 Hour / Minute (as numbers)	時/分 (数字)
 ISO Speed:	ISO感度:
 Image Pixels	画像のピクセル数
@@ -170,7 +170,7 @@ Increase/decrease contrast	コントラストの増減
 Increase/decrease darkening of highlights (LDC must be on)	ハイライトを暗く/明るく (LDC がオンの場合)
 Increase/decrease lightening of shadows (LDC must be on)	影を明るく/暗く (LDC がオンの場合)
 Increase/decrease sharpness	シャープの増減
-Insufficient rights to change the privilege (DACL) on the registry entry. Continue?	
+Insufficient rights to change the privilege (DACL) on the registry entry. Continue?	レジストリの項目を変更するの権限 (DACL) が十分ではありません。続行しますか？
 JPEGView Help	JPEGView ヘルプ
 JPEGView is a lean, fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF and TIFF images with a minimal GUI.	JPEGView は、JPEG、BMP、PNG、WEBP、TGA、GIF、TIFF に対応し、軽快・高速かつ広くカスタマイズできる余分な装飾を抑えた画像ビューア/エディターです。
 JPEGView is registered as default viewer for the selected file formats.	指定の画像形式で、JPEGView を既定のビューアに設定しました。
@@ -223,9 +223,9 @@ Number (consecutively numbered)	通し番号
 Number of CPU cores used	CPUコア数
 Number of JPEG files in folder: %d	フォルダ内のJPEGファイル数: %d
 Number with N digits	N桁の番号
-OK	
+OK	OK
 Old name	元の名前
-Open folder containing image and select in Windows Explorer	
+Open folder containing image and select in Windows Explorer	この画像が含まれるフォルダをエクスプローラで開き選択状態にする
 Open new image or slideshow file	画像またはスライドショーを開く
 Order files by	ファイルの順序
 Orientation:	印刷の向き:
@@ -337,9 +337,9 @@ Sort images by creation date, resp. modification date, resp. file name	作成日
 Source:	給紙方法:
 Target folders that do not yet exist are created as needed.	存在しないフォルダは作成されます。
 The directory '%s' does not contain any image files!	このフォルダに画像ファイルはありません。 %s
-The file '%s' could not be copied!	
+The file '%s' could not be copied!	このファイルをコピーできません。 %s
 The file '%s' could not be read!	 このファイルを読み込めません。 %s
-The file '%s' could not be renamed!	
+The file '%s' could not be renamed!	このファイルを改名できません。 %s
 The file '%s' does not contain a list of file names!	このファイル内にファイル名の一覧はありません。 %s
 The file is read-only!	このファイルは読み取り専用です。
 The following file extensions cannot be unregistered because they have been registered in the 'local machine' registry area.	以下の拡張子は、レジストリの 'local machine' 内で関連付けされているので登録を解除できません。
@@ -354,8 +354,8 @@ These values will override the values from the INI file located in the program f
 Threshold	閾値
 Title:	タイトル:
 Toggle between screens (only for multi-monitor systems)	マルチモニターで別画面に表示
-Toggle window always on top mode	
-Toggle window title bar hidden mode	
+Toggle window always on top mode	ウィンドウを常に手前に表示するモードを切り替え
+Toggle window title bar hidden mode	ウィンドウのタイトルバーを表示/隠すを切り替え
 Top	上
 Transition Effect	遷移時の視覚効果
 Trim the image and apply transformation? Trimming cannot be undone!	境界をトリミングして変形しますか？ 元に戻せません。
@@ -367,7 +367,7 @@ Use the mouse to draw a line that shall be horizontal or vertical.	マウスで�
 Warning	注意
 Width	幅
 Window mode	ウィンドウ表示
-Windows 8 (and above) blocks JPEGView from changing the default program for these file extensions.	
+Windows 8 (and above) blocks JPEGView from changing the default program for these file extensions.	Windows 8（またそれ以降）では、これらのファイル拡張子の既定のプログラムを JPEGView が変更することを阻止されます。
 Writing the resulting JPEG file to disk failed	JPEGファイル保存失敗
 Y - B	A - A
 Year short form (2 digits)	年数2桁
@@ -377,9 +377,9 @@ Zoom in (%s)/Zoom out (%s)	拡大(%s)/縮小(%s)
 Zoom in/out image	拡大/縮小
 Zoom mode (drag mouse to zoom)	拡大モード (マウスでドラッグ)
 and image processing (brightness/contrast/sharpen) parameters between images	明るさ、コントラスト、シャープのパラメーターを保持
-cm	
-in	
-new menu entry	
+cm	cm
+in	inch
+new menu entry	新しいメニュー項目
 no	なし
 off	オフ
 on	オン
@@ -409,14 +409,14 @@ Modification date	更新日時
 Creation date	作成日時
 Play folder as slideshow/movie	スライドショー/動画でフォルダを表示
 Waiting time	待ち時間
-1 sec	
-2 sec	
-3 sec	
-4 sec	
-5 sec	
-7 sec	
-10 sec	
-20 sec	
+1 sec	1秒
+2 sec	2秒
+3 sec	3秒
+4 sec	4秒
+5 sec	5秒
+7 sec	7秒
+10 sec	10秒
+20 sec	20秒
 Transition Speed	遷移時間
 Very fast	速い
 Fast	速め
@@ -424,13 +424,13 @@ Normal	標準
 Slow	遅め
 Very slow	遅い
 Movie	動画
-Playback speed	
-5 fps	
-10 fps	
-25 fps	
-30 fps	
-50 fps	
-100 fps	
+Playback speed	再生速度
+5 fps	5 fps
+10 fps	10 fps
+25 fps	25 fps
+30 fps	30 fps
+50 fps	50 fps
+100 fps	100 fps
 Transform image	画像の変形
 Rotate +90	+90度回転
 Rotate -90	-90度回転
@@ -484,37 +484,7 @@ Zoom to Selection	選択範囲を拡大
 //renamed	改名
 //up/down	上/下
 
-// ::: INFO: Missing Translations [30] ::: (Summary of all missing strings to assist translators - Auto-generated by script) //
-//! Clipboard Image
-//! Copy file path of the image to clipboard
-//! Decoding this format requires the Microsoft Visual C++ Redistributable.
-//! High quality resampling
-//! Insufficient rights to change the privilege (DACL) on the registry entry. Continue?
-//! OK
-//! Open folder containing image and select in Windows Explorer
-//! The file '%s' could not be copied!
-//! The file '%s' could not be renamed!
-//! Toggle window always on top mode
-//! Toggle window title bar hidden mode
-//! Windows 8 (and above) blocks JPEGView from changing the default program for these file extensions.
-//! cm
-//! in
-//! new menu entry
-//! 1 sec
-//! 2 sec
-//! 3 sec
-//! 4 sec
-//! 5 sec
-//! 7 sec
-//! 10 sec
-//! 20 sec
-//! Playback speed
-//! 5 fps
-//! 10 fps
-//! 25 fps
-//! 30 fps
-//! 50 fps
-//! 100 fps
+// ::: INFO: Missing Translations [0] ::: (Summary of all missing strings to assist translators - Auto-generated by script) //
 
 // ::: STATUS: Last Checked/Updated by Script ::: 2023-02-10T22:28:46.264876+00:00 //
 //! Translation Progress: 93%


### PR DESCRIPTION
Missing strings:
```
Upcounting
Downcounting
```

However, there is no problem with remaining in English. Japanese requires a space of 6 alphabetic characters for these strings:
```
cm	センチ
in	インチ
```

Above is a sample in Japanese. No problem at all in English.