### PR TITLE
Use GDI+ to load PNGs when ForceGDIPlus or UseEmbeddedColorProfiles is true

### DIFF
--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -350,7 +350,12 @@ void CImageLoadThread::ProcessRequest(CRequestBase& request) {
 			DeleteCachedWebpDecoder();
 			DeleteCachedJxlDecoder();
 			DeleteCachedAvifDecoder();
-			ProcessReadPNGRequest(&rq);
+			if (CSettingsProvider::This().ForceGDIPlus() || CSettingsProvider::This().UseEmbeddedColorProfiles()) {
+				DeleteCachedPngDecoder();
+				ProcessReadGDIPlusRequest(&rq);
+			} else {
+				ProcessReadPNGRequest(&rq);
+			}
 			break;
 		case IF_JXL:
 			DeleteCachedGDIBitmap();


### PR DESCRIPTION
This restores ICC profile support for PNGs when UseEmbeddedColorProfiles=true, but disables animation. For example, the bench in this image currently displays as green in JPEGView when it should be red.
![bench](https://raw.githubusercontent.com/libjxl/conformance/master/testcases/bench_oriented_brg/ref.png)
