### PR TITLE
Added Fixed Zoom Levels

### DIFF
--- a/src/JPEGView/MainDlg.cpp
+++ b/src/JPEGView/MainDlg.cpp
@@ -2602,8 +2602,21 @@ void CMainDlg::PerformZoom(double dValue, bool bExponent, bool bZoomToMouse, boo
 	double dOldZoom = m_dZoom;
 	m_bUserZoom = true;
 	m_isUserFitToScreen = false;
+
 	if (bExponent) {
 		m_dZoom = m_dZoom * pow(m_dZoomMult, dValue);
+
+		std::vector<double> zoomLevels = { 0.03, 0.05, 0.1, 0.14, 0.16, 0.20, 0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 4.0, 5.0 };
+
+		if (dOldZoom > zoomLevels[0] && dOldZoom < zoomLevels.back()) {
+			if (dValue > 0) {
+				m_dZoom = zoomLevels[distance(zoomLevels.begin(), std::lower_bound(zoomLevels.begin(), zoomLevels.end(), dOldZoom + 0.01))];
+			}
+			else {
+				m_dZoom = zoomLevels[distance(zoomLevels.begin(), std::lower_bound(zoomLevels.begin(), zoomLevels.end(), dOldZoom)) - 1];
+			}
+		}
+
 	} else {
 		m_dZoom = dValue;
 	}


### PR DESCRIPTION
Hi. I made changes so that the zoom-ins and zoom-outs made using the mouse scroll would have fixed percentages between 3% and 500%. It defaults to the previous exponent calculation outside of these levels. These levels are fixed in the code, but this can be made into a setting so that users can have their own fixed sizes.