### PR TITLE
Lepton support

### DIFF
--- a/src/JPEGView/FileExtensionsDlg.cpp
+++ b/src/JPEGView/FileExtensionsDlg.cpp
@@ -4,6 +4,7 @@
 #include "HelpersGUI.h"
 #include "SettingsProvider.h"
 #include "FileExtensionsRegistry.h"
+#include "LepLoader.h"
 
 ///////////////////////////////////////////////////////////////////////////////////
 // Helpers
@@ -293,18 +294,19 @@ void CFileExtensionsDlg::FillFileExtensionsList() {
 	InsertExtension(_T("*.qoi"), FormatHint(CNLS::GetString(_T("%s images")), _T("Quite OK Image")));
 	InsertExtensions(CSettingsProvider::This().FilesProcessedByWIC(), CNLS::GetString(_T("%s images (processed by Window Imaging Component - WIC)")));
 	InsertExtensions(CSettingsProvider::This().FileEndingsRAW(), CNLS::GetString(_T("%s camera raw images (embedded JPEGs only)")));
+	if (LepLoader::LeptonToolPresent())
+		InsertExtensions(CSettingsProvider::This().FilesProcessedByLepton(), CNLS::GetString(_T("%s images")), _T("Dropbox's Lepton"));
 }
 
-void CFileExtensionsDlg::InsertExtensions(LPCTSTR sExtensionList, LPCTSTR sHint) {
+void CFileExtensionsDlg::InsertExtensions(LPCTSTR sExtensionList, LPCTSTR sHint, LPCTSTR param) {
 	int nNumChars = (int)_tcslen(sExtensionList);
 	int nStart = 0;
 	for (int i = 0; i <= nNumChars; i++) {
 		if (sExtensionList[i] == _T(';') || sExtensionList[i] == 0) {
 			CString sExtension(&sExtensionList[nStart], i - nStart);
 			if (sExtension.GetLength() >= 3) {
-				CString sExtensionUpper(&((LPCTSTR)sExtension)[2]);
-				sExtensionUpper.MakeUpper();
-				InsertExtension(sExtension, FormatHint(sHint, sExtensionUpper));
+				CString sExtensionUpper(param ? param : &((LPCTSTR)sExtension)[2]);
+				InsertExtension(sExtension, FormatHint(sHint, param ? sExtensionUpper : sExtensionUpper.MakeUpper()));
 			}
 			nStart = i + 1;
 		}

--- a/src/JPEGView/FileExtensionsDlg.h
+++ b/src/JPEGView/FileExtensionsDlg.h
@@ -44,5 +44,5 @@ private:
 
 	void FillFileExtensionsList();
 	void InsertExtension(LPCTSTR sExtension, LPCTSTR sHint);
-	void InsertExtensions(LPCTSTR sExtensionList, LPCTSTR sHint);
+	void InsertExtensions(LPCTSTR sExtensionList, LPCTSTR sHint, LPCTSTR param = NULL);
 };

--- a/src/JPEGView/FileList.cpp
+++ b/src/JPEGView/FileList.cpp
@@ -4,6 +4,7 @@
 #include "Helpers.h"
 #include "DirectoryWatcher.h"
 #include "Shlwapi.h"
+#include "LepLoader.h"
 
 ///////////////////////////////////////////////////////////////////////////////////
 // Helpers
@@ -182,6 +183,11 @@ static LPCTSTR* GetSupportedFileEndingList() {
 		if (_tcslen(sFileEndingsWIC) > 2 && WICPresentGuarded()) {
 			ParseAndAddFileEndings(sFileEndingsWIC);
 		}
+
+		if (LepLoader::LeptonToolPresent()) {
+			ParseAndAddFileEndings(CSettingsProvider::This().FilesProcessedByLepton());
+		}
+
 		ParseAndAddFileEndings(CSettingsProvider::This().FileEndingsRAW());
 	}
 	return sFileEndings;

--- a/src/JPEGView/Helpers.cpp
+++ b/src/JPEGView/Helpers.cpp
@@ -777,6 +777,8 @@ EImageFormat GetImageFormat(LPCTSTR sFileName) {
 			return IF_WIC;
 		} else if (IsInFileEndingList(CSettingsProvider::This().FileEndingsRAW(), sEnding)) {
 			return IF_CameraRAW;
+		} else if (IsInFileEndingList(CSettingsProvider::This().FilesProcessedByLepton(), sEnding)) {
+			return IF_Lepton;
 		}
 	}
 	return IF_Unknown;
@@ -963,4 +965,19 @@ int GetWindowsVersion() {
 	return osvi.dwMajorVersion * 100 + osvi.dwMinorVersion;
 }
 
+CString GetTempPath() {
+	TCHAR tempPath[MAX_PATH];
+	tempPath[0] = 0;
+	::GetTempPath(MAX_PATH, tempPath);
+	return tempPath;
+}
+GUID GetGuid() {
+	GUID guid = GUID_NULL;
+	::CoCreateGuid(&guid);
+	return guid;
+}
+CString GetGuidString() {
+	CComBSTR guid(Helpers::GetGuid());
+	return CString(CW2T(guid));
+}
 }

--- a/src/JPEGView/Helpers.h
+++ b/src/JPEGView/Helpers.h
@@ -244,6 +244,12 @@ namespace Helpers {
 	// Returns the windows version in the format Major * 100 + Minor, e.g. 602 for Windows 8
 	int GetWindowsVersion();
 
+	// Returns the sysmem's temporary directory.
+	CString GetTempPath();
+
+	GUID GetGuid();
+	CString GetGuidString();
+
 	// Conversion class that replaces the | by null character in a string.
 	// Caution: Uses a static buffer and therefore only one string can be replaced concurrently
 	const int MAX_SIZE_REPLACE_PIPE = 512;

--- a/src/JPEGView/ImageLoadThread.h
+++ b/src/JPEGView/ImageLoadThread.h
@@ -107,6 +107,8 @@ private:
 	void DeleteCachedJxlDecoder();
 	void DeleteCachedAvifDecoder();
 
+	// Special overload for Lepton files, where actual Lepton file goes via a temporary file.
+	void ProcessReadJPEGRequest(CRequest* request, const CString& fileName);
 	void ProcessReadJPEGRequest(CRequest * request);
 	void ProcessReadPNGRequest(CRequest * request);
 	void ProcessReadBMPRequest(CRequest * request);
@@ -119,6 +121,7 @@ private:
 	void ProcessReadRAWRequest(CRequest * request);
 	void ProcessReadGDIPlusRequest(CRequest * request);
 	void ProcessReadWICRequest(CRequest* request);
+	void ProcessReadLeptonRequest(CRequest* request);
 
 	static void SetFileDependentProcessParams(CRequest * request);
 	static bool ProcessImageAfterLoad(CRequest * request);

--- a/src/JPEGView/ImageProcessingTypes.h
+++ b/src/JPEGView/ImageProcessingTypes.h
@@ -45,6 +45,7 @@ enum EImageFormat {
 	IF_CameraRAW,
 	IF_JPEG_Embedded, // JPEG embedded in another file, e.g. camera raw
 	IF_TGA,
+	IF_Lepton,
 	IF_Unknown
 };
 

--- a/src/JPEGView/JPEGView.vcxproj
+++ b/src/JPEGView/JPEGView.vcxproj
@@ -327,6 +327,7 @@
     <ClCompile Include="JPEGView.cpp" />
     <ClCompile Include="JXLWrapper.cpp" />
     <ClCompile Include="KeyMap.cpp" />
+    <ClCompile Include="LepLoader.cpp" />
     <ClCompile Include="LocalDensityCorr.cpp" />
     <ClCompile Include="ManageOpenWithDlg.cpp" />
     <ClCompile Include="MultiMonitorSupport.cpp" />
@@ -416,6 +417,7 @@
     <ClInclude Include="JPEGProvider.h" />
     <ClInclude Include="JXLWrapper.h" />
     <ClInclude Include="KeyMap.h" />
+    <ClInclude Include="LepLoader.h" />
     <ClInclude Include="LocalDensityCorr.h" />
     <ClInclude Include="ManageOpenWithDlg.h" />
     <ClInclude Include="MaxImageDef.h" />

--- a/src/JPEGView/JPEGView.vcxproj.filters
+++ b/src/JPEGView/JPEGView.vcxproj.filters
@@ -285,6 +285,9 @@
     <ClCompile Include="ICCProfileTransform.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="LepLoader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BasicProcessing.h">
@@ -549,6 +552,9 @@
       <Filter>Header Files\Image Types</Filter>
     </ClInclude>
     <ClInclude Include="ICCProfileTransform.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LepLoader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/JPEGView/LepLoader.cpp
+++ b/src/JPEGView/LepLoader.cpp
@@ -1,0 +1,13 @@
+#include "stdafx.h"
+#include "LepLoader.h"
+#include "SettingsProvider.h"
+
+bool LepLoader::LeptonToolPresent()
+{
+	return (::GetFileAttributes(GetToolPath()) != INVALID_FILE_ATTRIBUTES);
+}
+
+CString LepLoader::GetToolPath()
+{
+	return CString(CSettingsProvider::This().GetEXEPath()) + CSettingsProvider::This().LeptonToolName();
+}

--- a/src/JPEGView/LepLoader.h
+++ b/src/JPEGView/LepLoader.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class LepLoader
+{
+public:
+	static bool LeptonToolPresent();
+
+	// Gets the path where the global INI file and the EXE is located
+	static CString GetToolPath();
+};
+

--- a/src/JPEGView/SettingsProvider.cpp
+++ b/src/JPEGView/SettingsProvider.cpp
@@ -177,6 +177,9 @@ CSettingsProvider::CSettingsProvider(void) {
 	m_nWEBPSaveQuality = GetInt(_T("WEBPSaveQuality"), 85, 0, 100);
 	m_sDefaultSaveFormat = GetString(_T("DefaultSaveFormat"), _T("jpg"));
 	m_sFilesProcessedByWIC = GetString(_T("FilesProcessedByWIC"), _T("*.wdp;*.mdp;*.hdp"));
+	m_sFilesProcessedByLepton = GetString(_T("FilesProcessedByLepton"), _T("*.lep"));
+	m_sLeptonToolName = GetString(_T("LeptonToolName"), _T("lepton-avx.exe"));
+	m_sLeptonToolExtraArgs = GetString(_T("LeptonToolExtraArgs"), _T("-allowprogressive -memory=1024M -threadmemory=128M"));
 	m_sFileEndingsRAW = GetString(_T("FileEndingsRAW"), _T("*.pef;*.dng;*.crw;*.nef;*.cr2;*.mrw;*.rw2;*.orf;*.x3f;*.arw;*.kdc;*.nrw;*.dcr;*.sr2;*.raf"));
 	m_bCreateParamDBEntryOnSave = GetBool(_T("CreateParamDBEntryOnSave"), true);
 	m_bWrapAroundFolder = GetBool(_T("WrapAroundFolder"), true);
@@ -285,10 +288,7 @@ CSettingsProvider::CSettingsProvider(void) {
 
 	m_sWallpaperPath = GetString(_T("WallpaperPath"), _T("%temp%"));
 	if (m_sWallpaperPath == _T("%temp%")) {
-		TCHAR tempPath[MAX_PATH];
-		tempPath[0] = 0;
-		::GetTempPath(MAX_PATH, tempPath);
-		m_sWallpaperPath = tempPath;
+		m_sWallpaperPath = Helpers::GetTempPath();
 	}
 	else {
 		TCHAR buffer[MAX_PATH];

--- a/src/JPEGView/SettingsProvider.h
+++ b/src/JPEGView/SettingsProvider.h
@@ -77,6 +77,9 @@ public:
 	int WEBPSaveQuality() { return m_nWEBPSaveQuality; }
 	LPCTSTR DefaultSaveFormat() { return m_sDefaultSaveFormat; }
 	LPCTSTR FilesProcessedByWIC() { return m_sFilesProcessedByWIC; }
+	LPCTSTR FilesProcessedByLepton() { return m_sFilesProcessedByLepton; }
+	const CString& LeptonToolName() const { return m_sLeptonToolName; }
+	const CString& LeptonToolExtraArgs() const { return m_sLeptonToolExtraArgs; }
 	LPCTSTR FileEndingsRAW() { return m_sFileEndingsRAW; }
 	void AddTemporaryRAWFileEnding(LPCTSTR sEnding) { m_sFileEndingsRAW += CString(_T(";*.")) + sEnding; }
 	bool CreateParamDBEntryOnSave() { return m_bCreateParamDBEntryOnSave; }
@@ -244,6 +247,9 @@ private:
 	int m_nWEBPSaveQuality;
 	CString m_sDefaultSaveFormat;
 	CString m_sFilesProcessedByWIC;
+	CString m_sFilesProcessedByLepton;
+	CString m_sLeptonToolName;
+	CString m_sLeptonToolExtraArgs;
 	CString m_sFileEndingsRAW;
 	bool m_bCreateParamDBEntryOnSave;
 	bool m_bWrapAroundFolder;

--- a/src/JPEGView/stdafx.h
+++ b/src/JPEGView/stdafx.h
@@ -61,6 +61,10 @@ extern CAppModule _Module;
 #error _UNICODE symbol must be defined
 #endif
 
+#ifndef STARTF_UNTRUSTEDSOURCE
+#define STARTF_UNTRUSTEDSOURCE     0x00008000
+#endif
+
 #if defined _M_IX86
   #pragma comment(linker, "/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='x86' publicKeyToken='6595b64144ccf1df' language='*'\"")
 #elif defined _M_IA64


### PR DESCRIPTION
* Added support for [Dropbox Lepton](https://github.com/dropbox/lepton) image format for images with *.lep extension. lepton-avx.exe has to be downloaded from https://github.com/dropbox/lepton/releases/download/1.2/lepton-avx.exe and placed to JPEGView folder. 

   Default Lepton parameters can be changed in config:
``LeptonToolName=lepton-avx.exe``
``LeptonToolExtraArgs=-allowprogressive -memory=1024M -threadmemory=128M``
``FilesProcessedByLepton=*.lep``

Examples of Dropbox Lepton images can be found there: https://github.com/microsoft/lepton_jpeg_rust/tree/main/images