### PR TITLE
Make animation frametimes appear closer to their actual values

### DIFF
--- a/src/JPEGView/MainDlg.cpp
+++ b/src/JPEGView/MainDlg.cpp
@@ -3484,6 +3484,7 @@ void CMainDlg::AdjustAnimationFrameTime() {
 	// restart timer with new frame time
 	::KillTimer(this->m_hWnd, ANIMATION_TIMER_EVENT_ID);
 	m_nLastAnimationOffset += ::GetTickCount() - m_nExpectedNextAnimationTickCount;
+	m_nLastAnimationOffset = min(m_nLastAnimationOffset, max(100, m_pCurrentImage->FrameTimeMs())); // prevent offset from getting too big
 	int nNewFrameTime = max(10, m_pCurrentImage->FrameTimeMs() - max(0, m_nLastAnimationOffset));
 	m_nExpectedNextAnimationTickCount = ::GetTickCount() + max(10, m_pCurrentImage->FrameTimeMs());
 	::SetTimer(this->m_hWnd, ANIMATION_TIMER_EVENT_ID, nNewFrameTime, NULL);

--- a/src/JPEGView/MainDlg.cpp
+++ b/src/JPEGView/MainDlg.cpp
@@ -257,6 +257,8 @@ CMainDlg::CMainDlg(bool bForceFullScreen) {
 	m_bMouseOn = false;
 	m_bKeepParametersBeforeAnimation = false;
 	m_bIsAnimationPlaying = false;
+	m_nLastAnimationOffset = 0;
+	m_nExpectedNextAnimationTickCount = 0;
 	m_bUseLosslessWEBP = false;
 	m_isBeforeFileSelected = true;
 	m_dLastImageDisplayTime = 0.0;
@@ -3470,15 +3472,21 @@ void CMainDlg::StartAnimation() {
 	m_bLDC = false;
 	m_bLandscapeMode = false;
 	m_bIsAnimationPlaying = true;
-	::SetTimer(this->m_hWnd, ANIMATION_TIMER_EVENT_ID, max(10, m_pCurrentImage->FrameTimeMs()), NULL);
+	int nNewFrameTime = max(10, m_pCurrentImage->FrameTimeMs());
+	::SetTimer(this->m_hWnd, ANIMATION_TIMER_EVENT_ID, nNewFrameTime, NULL);
 	m_pNavPanelCtl->EndNavPanelAnimation();
 	m_nLastSlideShowImageTickCount = ::GetTickCount();
+	m_nLastAnimationOffset = 0;
+	m_nExpectedNextAnimationTickCount = ::GetTickCount() + nNewFrameTime;
 }
 
 void CMainDlg::AdjustAnimationFrameTime() {
 	// restart timer with new frame time
 	::KillTimer(this->m_hWnd, ANIMATION_TIMER_EVENT_ID);
-	::SetTimer(this->m_hWnd, ANIMATION_TIMER_EVENT_ID, max(10, m_pCurrentImage->FrameTimeMs()), NULL);
+	m_nLastAnimationOffset += ::GetTickCount() - m_nExpectedNextAnimationTickCount;
+	int nNewFrameTime = max(10, m_pCurrentImage->FrameTimeMs() - max(0, m_nLastAnimationOffset));
+	m_nExpectedNextAnimationTickCount = ::GetTickCount() + max(10, m_pCurrentImage->FrameTimeMs());
+	::SetTimer(this->m_hWnd, ANIMATION_TIMER_EVENT_ID, nNewFrameTime, NULL);
 }
 
 void CMainDlg::StopAnimation() {

--- a/src/JPEGView/MainDlg.h
+++ b/src/JPEGView/MainDlg.h
@@ -301,6 +301,8 @@ private:
 	bool m_bMouseOn;
 	bool m_bKeepParametersBeforeAnimation;
 	bool m_bIsAnimationPlaying;
+	int m_nLastAnimationOffset;
+	int m_nExpectedNextAnimationTickCount;
 	int m_nMonitor;
 	WINDOWPLACEMENT m_storedWindowPlacement;
 	CRect m_monitorRect;


### PR DESCRIPTION
For animated images, JPEGView currently sets a timer to wait for the next frame based on each frame's frametime. This doesn't account for the time we spend processing each frame, so the image ends up playing slower than it does in a browser or video player. To fix this, we calculate an offset based on the difference between each frametime and the actual time that the frame took to render. This isn't a perfect solution, but animated images should no longer be noticeably slower than in a browser.