### PR TITLE
JXL/HEIF/AVIF/WebP/PNG Exif data support

### DIFF
--- a/src/JPEGView/AVIFWrapper.h
+++ b/src/JPEGView/AVIFWrapper.h
@@ -14,6 +14,7 @@ public:
 		int frame_index, // index of frame
 		int& frame_count, // number of frames
 		int& frame_time, // frame duration in milliseconds
+		void*& exif_chunk, // Pointer to Exif data (must be freed by caller)
 		bool& outOfMemory, // set to true when no memory to read image
 		const void* buffer, // memory address containing jxl compressed data.
 		int sizebytes); // size of jxl compressed data

--- a/src/JPEGView/EXIFDisplayCtl.cpp
+++ b/src/JPEGView/EXIFDisplayCtl.cpp
@@ -121,7 +121,7 @@ void CEXIFDisplayCtl::FillEXIFDataDisplay() {
 		CRawMetadata* pRawMetaData = CurrentImage()->GetRawMetadata();
 		if (pEXIFReader != NULL) {
 			sComment = pEXIFReader->GetUserComment();
-			if (sComment == NULL || sComment[0] == 0) {
+			if (sComment == NULL || sComment[0] == 0 || ((std::wstring) sComment).find_first_not_of(L" \t\n\r\f\v", 0) == std::wstring::npos) {
 				sComment = pEXIFReader->GetImageDescription();
 			}
 			if (pEXIFReader->GetAcquisitionTimePresent()) {
@@ -201,7 +201,7 @@ void CEXIFDisplayCtl::FillEXIFDataDisplay() {
 		}
 	}
 
-	if (sComment == NULL || sComment[0] == 0) {
+	if (sComment == NULL || sComment[0] == 0 || ((std::wstring)sComment).find_first_not_of(L" \t\n\r\f\v", 0) == std::wstring::npos) {
 		sComment = CurrentImage()->GetJPEGComment();
 	}
 	if (CSettingsProvider::This().ShowJPEGComments() && sComment != NULL && sComment[0] != 0) {

--- a/src/JPEGView/EXIFReader.cpp
+++ b/src/JPEGView/EXIFReader.cpp
@@ -241,7 +241,7 @@ bool CEXIFReader::ParseDateString(SYSTEMTIME & date, const CString& str) {
 	return false;
 }
 
-CEXIFReader::CEXIFReader(void* pApp1Block) 
+CEXIFReader::CEXIFReader(void* pApp1Block, EImageFormat eImageFormat)
 : m_exposureTime(0, 0) {
 
 	memset(&m_acqDate, 0, sizeof(SYSTEMTIME));
@@ -297,7 +297,11 @@ CEXIFReader::CEXIFReader(void* pApp1Block)
 	m_pLastIFD0 = pLastIFD0;
 
 	// image orientation
-	uint8* pTagOrientation = FindTag(pIFD0, pLastIFD0, 0x112, bLittleEndian);
+	uint8* pTagOrientation = NULL;
+	// orientation tags must be ignored for JXL, they are taken care of by the decoder
+	if (eImageFormat != IF_JXL) {
+		pTagOrientation = FindTag(pIFD0, pLastIFD0, 0x112, bLittleEndian);
+	}
 	if (pTagOrientation != NULL) {
 		m_nImageOrientation = ReadShortTag(pTagOrientation, bLittleEndian);
 	}

--- a/src/JPEGView/EXIFReader.h
+++ b/src/JPEGView/EXIFReader.h
@@ -38,7 +38,7 @@ public:
 	// The pApp1Block must point to the APP1 block of the EXIF data, including the APP1 block marker
 	// The class does not take ownership of the memory (no copy made), thus the APP1 block must not be deleted
 	// while the EXIF reader class is deleted.
-	CEXIFReader(void* pApp1Block);
+	CEXIFReader(void* pApp1Block, EImageFormat eImageFormat);
 	~CEXIFReader(void);
 
 	// Parse date string in the EXIF date/time format

--- a/src/JPEGView/HEIFWrapper.cpp
+++ b/src/JPEGView/HEIFWrapper.cpp
@@ -75,11 +75,13 @@ void * HeifReader::ReadImage(int &width,
 
 	if (!exif_blocks.empty()) {
 		std::vector<uint8_t> exif = handle.get_metadata(exif_blocks[0]);
-		exif_chunk = exif.size() > 8 ? (uint8_t*)malloc(exif.size()) : NULL;
-		if (exif_chunk != NULL) {
-			memcpy(exif_chunk, exif.data(), exif.size());
-			*((unsigned short*)exif_chunk) = _byteswap_ushort(0xFFE1);
-			*((unsigned short*)exif_chunk + 1) = _byteswap_ushort(exif.size() - 2);
+		if (exif.size() > 8 && exif.size() < 65538) {
+			exif_chunk = malloc(exif.size());
+			if (exif_chunk != NULL) {
+				memcpy(exif_chunk, exif.data(), exif.size());
+				*((unsigned short*)exif_chunk) = _byteswap_ushort(0xFFE1);
+				*((unsigned short*)exif_chunk + 1) = _byteswap_ushort(exif.size() - 2);
+			}
 		}
 	}
 

--- a/src/JPEGView/HEIFWrapper.cpp
+++ b/src/JPEGView/HEIFWrapper.cpp
@@ -8,6 +8,7 @@ void * HeifReader::ReadImage(int &width,
 					   int &height,
 					   int &nchannels,
 					   int &frame_count,
+					   void* &exif_chunk,
 					   bool &outOfMemory,
 					   int frame_index,
 					   const void *buffer,
@@ -18,6 +19,7 @@ void * HeifReader::ReadImage(int &width,
 	nchannels = 4;
 
 	unsigned char* pPixelData = NULL;
+	exif_chunk = NULL;
 
 	heif::Context context;
 	context.read_from_memory_without_copy(buffer, sizebytes);
@@ -68,6 +70,18 @@ void * HeifReader::ReadImage(int &width,
 		}
 	}
 	ICCProfileTransform::DeleteTransform(transform);
+
+	std::vector<heif_item_id> exif_blocks = handle.get_list_of_metadata_block_IDs("Exif");
+
+	if (!exif_blocks.empty()) {
+		std::vector<uint8_t> exif = handle.get_metadata(exif_blocks[0]);
+		exif_chunk = exif.size() > 8 ? (uint8_t*)malloc(exif.size()) : NULL;
+		if (exif_chunk != NULL) {
+			memcpy(exif_chunk, exif.data(), exif.size());
+			*((unsigned short*)exif_chunk) = _byteswap_ushort(0xFFE1);
+			*((unsigned short*)exif_chunk + 1) = _byteswap_ushort(exif.size() - 2);
+		}
+	}
 
 	return (void*)pPixelData;
 }

--- a/src/JPEGView/HEIFWrapper.h
+++ b/src/JPEGView/HEIFWrapper.h
@@ -10,6 +10,7 @@ public:
 						 int &height,  // height of the image loaded.
 						 int &bpp,     // BYTES (not bits) PER PIXEL.
 						 int &frame_count, // number of top-level images
+					     void* &exif_chunk, // Pointer to Exif data (must be freed by caller)
 						 bool &outOfMemory, // set to true when no memory to read image
 						 int frame_index, // index of requested frame
 						 const void *buffer, // memory address containing heic compressed data.

--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -860,8 +860,9 @@ void CImageLoadThread::ProcessReadAVIFRequest(CRequest* request) {
 		if (bUseCachedDecoder || (::ReadFile(hFile, pBuffer, nFileSize, (LPDWORD)&nNumBytesRead, NULL) && nNumBytesRead == nFileSize)) {
 			int nWidth, nHeight, nBPP, nFrameCount, nFrameTimeMs;
 			bool bHasAnimation;
+			void* pEXIFData;
 			uint8* pPixelData = (uint8*)AvifReader::ReadImage(nWidth, nHeight, nBPP, bHasAnimation, request->FrameIndex, 
-				nFrameCount, nFrameTimeMs, request->OutOfMemory, pBuffer, nFileSize);
+				nFrameCount, nFrameTimeMs, pEXIFData, request->OutOfMemory, pBuffer, nFileSize);
 			if (pPixelData != NULL) {
 				if (bHasAnimation)
 					m_sLastAvifFileName = sFileName;
@@ -870,7 +871,8 @@ void CImageLoadThread::ProcessReadAVIFRequest(CRequest* request) {
 				for (int i = 0; i < nWidth * nHeight; i++)
 					*pImage32++ = WebpAlphaBlendBackground(*pImage32, CSettingsProvider::This().ColorTransparency());
 
-				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, NULL, 4, 0, IF_AVIF, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, pEXIFData, 4, 0, IF_AVIF, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				free(pEXIFData);
 				bSuccess = true;
 			} else {
 				DeleteCachedAvifDecoder();

--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -638,7 +638,8 @@ void CImageLoadThread::ProcessReadWEBPRequest(CRequest * request) {
 			int nFrameCount = 1;
 			int nFrameTimeMs = 0;
 			int nBPP;
-			uint8* pPixelData = (uint8*)WebpReaderWriter::ReadImage(nWidth, nHeight, nBPP, bHasAnimation, nFrameCount, nFrameTimeMs, request->OutOfMemory, pBuffer, nFileSize);
+			void* pEXIFData;
+			uint8* pPixelData = (uint8*)WebpReaderWriter::ReadImage(nWidth, nHeight, nBPP, bHasAnimation, nFrameCount, nFrameTimeMs, pEXIFData, request->OutOfMemory, pBuffer, nFileSize);
 			if (pPixelData && nBPP == 4) {
 				// Multiply alpha value into each AABBGGRR pixel
 				uint32* pImage32 = (uint32*)pPixelData;
@@ -648,7 +649,8 @@ void CImageLoadThread::ProcessReadWEBPRequest(CRequest * request) {
 				if (bHasAnimation) {
 					m_sLastWebpFileName = sFileName;
 				}
-				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, NULL, nBPP, 0, IF_WEBP, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, pEXIFData, nBPP, 0, IF_WEBP, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				free(pEXIFData);
 			}
 			else {
 				delete[] pPixelData;

--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -712,10 +712,11 @@ void CImageLoadThread::ProcessReadPNGRequest(CRequest* request) {
 			int nWidth, nHeight, nBPP, nFrameCount, nFrameTimeMs;
 			bool bHasAnimation;
 			uint8* pPixelData = NULL;
+			void* pEXIFData;
 
 			// If UseEmbeddedColorProfiles is true and the image isn't animated, we should use GDI+ for better color management
 			if (bUseCachedDecoder || !CSettingsProvider::This().UseEmbeddedColorProfiles() || PngReader::IsAnimated(pBuffer, nFileSize))
-				pPixelData = (uint8*)PngReader::ReadImage(nWidth, nHeight, nBPP, bHasAnimation, nFrameCount, nFrameTimeMs, request->OutOfMemory, pBuffer, nFileSize);
+				pPixelData = (uint8*)PngReader::ReadImage(nWidth, nHeight, nBPP, bHasAnimation, nFrameCount, nFrameTimeMs, pEXIFData, request->OutOfMemory, pBuffer, nFileSize);
 
 			if (pPixelData != NULL) {
 				if (bHasAnimation)
@@ -725,7 +726,8 @@ void CImageLoadThread::ProcessReadPNGRequest(CRequest* request) {
 				for (int i = 0; i < nWidth * nHeight; i++)
 					*pImage32++ = WebpAlphaBlendBackground(*pImage32, CSettingsProvider::This().ColorTransparency());
 
-				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, NULL, 4, 0, IF_PNG, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, pEXIFData, 4, 0, IF_PNG, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				free(pEXIFData);
 				bSuccess = true;
 			}
 			else {

--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -922,14 +922,16 @@ void CImageLoadThread::ProcessReadHEIFRequest(CRequest* request) {
 			int nWidth, nHeight, nBPP, nFrameCount, nFrameTimeMs;
 			nFrameCount = 1;
 			nFrameTimeMs = 0;
-			uint8* pPixelData = (uint8*)HeifReader::ReadImage(nWidth, nHeight, nBPP, nFrameCount, request->OutOfMemory, request->FrameIndex, pBuffer, nFileSize);
+			void* pEXIFData;
+			uint8* pPixelData = (uint8*)HeifReader::ReadImage(nWidth, nHeight, nBPP, nFrameCount, pEXIFData, request->OutOfMemory, request->FrameIndex, pBuffer, nFileSize);
 			if (pPixelData != NULL) {
 				// Multiply alpha value into each AABBGGRR pixel
 				uint32* pImage32 = (uint32*)pPixelData;
 				for (int i = 0; i < nWidth * nHeight; i++)
 					*pImage32++ = WebpAlphaBlendBackground(*pImage32, CSettingsProvider::This().ColorTransparency());
 
-				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, NULL, nBPP, 0, IF_HEIF, false, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, pEXIFData, nBPP, 0, IF_HEIF, false, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				free(pEXIFData);
 			}
 		}
 	} catch(heif::Error he) {

--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -787,7 +787,8 @@ void CImageLoadThread::ProcessReadJXLRequest(CRequest* request) {
 		if (bUseCachedDecoder || (::ReadFile(hFile, pBuffer, nFileSize, (LPDWORD)&nNumBytesRead, NULL) && nNumBytesRead == nFileSize)) {
 			int nWidth, nHeight, nBPP, nFrameCount, nFrameTimeMs;
 			bool bHasAnimation;
-			uint8* pPixelData = (uint8*)JxlReader::ReadImage(nWidth, nHeight, nBPP, bHasAnimation, nFrameCount, nFrameTimeMs, request->OutOfMemory, pBuffer, nFileSize);
+			void* pEXIFData;
+			uint8* pPixelData = (uint8*)JxlReader::ReadImage(nWidth, nHeight, nBPP, bHasAnimation, nFrameCount, nFrameTimeMs, pEXIFData, request->OutOfMemory, pBuffer, nFileSize);
 			if (pPixelData != NULL) {
 				if (bHasAnimation)
 					m_sLastJxlFileName = sFileName;
@@ -796,7 +797,8 @@ void CImageLoadThread::ProcessReadJXLRequest(CRequest* request) {
 				for (int i = 0; i < nWidth * nHeight; i++)
 					*pImage32++ = WebpAlphaBlendBackground(*pImage32, CSettingsProvider::This().ColorTransparency());
 
-				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, NULL, 4, 0, IF_JXL, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				request->Image = new CJPEGImage(nWidth, nHeight, pPixelData, pEXIFData, 4, 0, IF_JXL, bHasAnimation, request->FrameIndex, nFrameCount, nFrameTimeMs);
+				free(pEXIFData);
 			} else {
 				DeleteCachedJxlDecoder();
 			}

--- a/src/JPEGView/JPEGImage.cpp
+++ b/src/JPEGView/JPEGImage.cpp
@@ -83,7 +83,7 @@ CJPEGImage::CJPEGImage(int nWidth, int nHeight, void* pPixels, void* pEXIFData, 
 		m_nEXIFSize = pEXIF[2]*256 + pEXIF[3] + 2;
 		m_pEXIFData = new char[m_nEXIFSize];
 		memcpy(m_pEXIFData, pEXIFData, m_nEXIFSize);
-		m_pEXIFReader = new CEXIFReader(m_pEXIFData);
+		m_pEXIFReader = new CEXIFReader(m_pEXIFData, eImageFormat);
 	} else {
 		m_nEXIFSize = 0;
 		m_pEXIFData = NULL;

--- a/src/JPEGView/JXLWrapper.cpp
+++ b/src/JPEGView/JXLWrapper.cpp
@@ -23,8 +23,9 @@ struct JxlReader::jxl_cache {
 JxlReader::jxl_cache JxlReader::cache = { 0 };
 
 // based on https://github.com/libjxl/libjxl/blob/main/examples/decode_oneshot.cc
-bool JxlReader::DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector<uint8_t>* pixels, int& xsize,
-	int& ysize, bool& have_animation, int& frame_count, int& frame_time, std::vector<uint8_t>* icc_profile, bool& outOfMemory) {
+// and https://github.com/libjxl/libjxl/blob/main/examples/decode_exif_metadata.cc
+bool JxlReader::DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector<uint8_t>* pixels, int& xsize, int& ysize,
+	bool& have_animation, int& frame_count, int& frame_time, std::vector<uint8_t>* icc_profile, std::vector<uint8_t>* exif, bool& outOfMemory) {
 
 	if (cache.decoder.get() == NULL) {
 		cache.runner = JxlResizableParallelRunnerMake(nullptr);
@@ -33,11 +34,15 @@ bool JxlReader::DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector
 		if (JXL_DEC_SUCCESS !=
 			JxlDecoderSubscribeEvents(cache.decoder.get(), JXL_DEC_BASIC_INFO |
 				JXL_DEC_COLOR_ENCODING |
+				JXL_DEC_BOX |
 				JXL_DEC_FRAME |
 				JXL_DEC_FULL_IMAGE)) {
 			return false;
 		}
 
+		if (JXL_DEC_SUCCESS != JxlDecoderSetDecompressBoxes(cache.decoder.get(), JXL_TRUE)) {
+			return false;
+		}
 
 		if (JXL_DEC_SUCCESS != JxlDecoderSetParallelRunner(cache.decoder.get(),
 			JxlResizableParallelRunner,
@@ -53,6 +58,8 @@ bool JxlReader::DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector
 
 	JxlBasicInfo info;
 	JxlPixelFormat format = { 4, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0 };
+	const constexpr size_t kChunkSize = 65536;
+	size_t output_pos = 0;
 
 	bool loop_check = false;
 	for (;;) {
@@ -139,6 +146,26 @@ bool JxlReader::DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector
 			JxlDecoderSubscribeEvents(cache.decoder.get(), JXL_DEC_FRAME | JXL_DEC_FULL_IMAGE);
 			JxlDecoderSetInput(cache.decoder.get(), cache.data, cache.data_size);
 			JxlDecoderCloseInput(cache.decoder.get());
+		} else if (status == JXL_DEC_BOX) {
+			if (!exif->empty()) {
+				size_t remaining = JxlDecoderReleaseBoxBuffer(cache.decoder.get());
+				exif->resize(exif->size() - remaining);
+			} else {
+				JxlBoxType type;
+				if (JXL_DEC_SUCCESS !=
+					JxlDecoderGetBoxType(cache.decoder.get(), type, true)) {
+					return false;
+				}
+				if (!memcmp(type, "Exif", 4)) {
+					exif->resize(kChunkSize);
+					JxlDecoderSetBoxBuffer(cache.decoder.get(), exif->data(), exif->size());
+				}
+			}
+		} else if (status == JXL_DEC_BOX_NEED_MORE_OUTPUT) {
+			size_t remaining = JxlDecoderReleaseBoxBuffer(cache.decoder.get());
+			output_pos += kChunkSize - remaining;
+			exif->resize(exif->size() + kChunkSize);
+			JxlDecoderSetBoxBuffer(cache.decoder.get(), exif->data() + output_pos, exif->size() - output_pos);
 		} else {
 			return false;
 		}
@@ -151,6 +178,7 @@ void* JxlReader::ReadImage(int& width,
 	bool& has_animation,
 	int& frame_count,
 	int& frame_time,
+	void*& exif_chunk,
 	bool& outOfMemory,
 	const void* buffer,
 	int sizebytes)
@@ -160,12 +188,14 @@ void* JxlReader::ReadImage(int& width,
 	nchannels = 4;
 	has_animation = false;
 	unsigned char* pPixelData = NULL;
+	exif_chunk = NULL;
 
 
 	std::vector<uint8_t> pixels;
 	std::vector<uint8_t> icc_profile;
+	std::vector<uint8_t> exif;
 	if (!DecodeJpegXlOneShot((const uint8_t*)buffer, sizebytes, &pixels, width, height,
-		has_animation, frame_count, frame_time, &icc_profile, outOfMemory)) {
+		has_animation, frame_count, frame_time, &icc_profile, &exif, outOfMemory)) {
 		return NULL;
 	}
 	int size = width * height * nchannels;
@@ -184,6 +214,16 @@ void* JxlReader::ReadImage(int& width,
 	}
 	if (!has_animation)
 		DeleteCache();
+
+	// Copy Exif data into the format understood by CEXIFReader
+	if (!exif.empty() && exif.size() > 8 && exif.size() < 65532) {
+		exif_chunk = malloc(exif.size() + 6);
+		if (exif_chunk != NULL) {
+			memcpy(exif_chunk, "\xFF\xE1\0\0Exif\0\0", 10);
+			*((unsigned short*)exif_chunk + 1) = _byteswap_ushort(exif.size() + 4);
+			memcpy((uint8_t*)exif_chunk + 10, exif.data() + 4, exif.size() - 4);
+		}
+	}
 	return pPixelData;
 }
 

--- a/src/JPEGView/JXLWrapper.h
+++ b/src/JPEGView/JXLWrapper.h
@@ -13,6 +13,7 @@ public:
 		bool& has_animation,     // if the image is animated
 		int& frame_count, // number of frames
 		int& frame_time, // frame duration in milliseconds
+		void*& exif, // Pointer to Exif data (must be freed by caller)
 		bool& outOfMemory, // set to true when no memory to read image
 		const void* buffer, // memory address containing jxl compressed data.
 		int sizebytes); // size of jxl compressed data
@@ -22,6 +23,6 @@ public:
 private:
 	struct jxl_cache;
 	static jxl_cache cache;
-	static bool DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector<uint8_t>* pixels, int& xsize,
-		int& ysize, bool& have_animation, int& frame_count, int& frame_time, std::vector<uint8_t>* icc_profile, bool& outOfMemory);
+	static bool DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector<uint8_t>* pixels, int& xsize, int& ysize,
+		bool& have_animation, int& frame_count, int& frame_time, std::vector<uint8_t>* icc_profile, std::vector<uint8_t>* exif, bool& outOfMemory);
 };

--- a/src/JPEGView/JXLWrapper.h
+++ b/src/JPEGView/JXLWrapper.h
@@ -23,6 +23,6 @@ public:
 private:
 	struct jxl_cache;
 	static jxl_cache cache;
-	static bool DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector<uint8_t>* pixels, int& xsize, int& ysize,
-		bool& have_animation, int& frame_count, int& frame_time, std::vector<uint8_t>* icc_profile, std::vector<uint8_t>* exif, bool& outOfMemory);
+	static bool DecodeJpegXlOneShot(const uint8_t* jxl, size_t size, std::vector<uint8_t>* pixels, int& xsize,
+		int& ysize, bool& have_animation, int& frame_count, int& frame_time, std::vector<uint8_t>* icc_profile, bool& outOfMemory);
 };

--- a/src/JPEGView/PNGWrapper.h
+++ b/src/JPEGView/PNGWrapper.h
@@ -11,6 +11,7 @@ public:
 		bool& has_animation,     // if the image is animated
 		int& frame_count, // number of frames
 		int& frame_time, // frame duration in milliseconds
+		void*& exif_chunk, // Pointer to Exif data (must be freed by caller)
 		bool& outOfMemory, // set to true when no memory to read image
 		void* buffer, // memory address containing png compressed data.
 		size_t sizebytes); // size of png compressed data
@@ -24,6 +25,6 @@ private:
 	struct png_cache;
 	static png_cache cache;
 	static bool BeginReading(void* buffer, size_t sizebytes, bool& outOfMemory);
-	static void* ReadNextFrame();
+	static void* ReadNextFrame(void** exif_chunk, unsigned int* exif_size);
 	static void DeleteCacheInternal(bool free_buffer);
 };

--- a/src/JPEGView/SaveImage.cpp
+++ b/src/JPEGView/SaveImage.cpp
@@ -163,7 +163,7 @@ static void* CompressAndSave(LPCTSTR sFileName, CJPEGImage * pImage,
 		memcpy(pNewStream + 2, pImage->GetEXIFData(), pImage->GetEXIFDataLength()); // copy EXIF block
 		
 		// Set image orientation back to normal orientation, we save the pixels as displayed
-		CEXIFReader exifReader(pNewStream + 2);
+		CEXIFReader exifReader(pNewStream + 2, IF_JPEG);
 		exifReader.WriteImageOrientation(1); // 1 means default orientation (unrotated)
 		if (bDeleteThumbnail) {
 			exifReader.DeleteThumbnail();

--- a/src/JPEGView/WEBPWrapper.h
+++ b/src/JPEGView/WEBPWrapper.h
@@ -11,6 +11,7 @@ public:
 		bool& has_animation,     // if the image is animated
 		int& frame_count, // number of frames
 		int& frame_time, // frame duration in milliseconds
+		void*& exif, // Pointer to Exif data (must be freed by caller)
 		bool& outOfMemory, // set to true when no memory to read image
 		const void* buffer, // memory address containing webp compressed data.
 		int sizebytes); // size of webp compressed data


### PR DESCRIPTION
Adds support for reading JPEG XL, HEIF, AVIF, WebP and PNG Exif data. ~~Doesn't work for animated JXLs~~. https://github.com/sylikc/jpegview/pull/213/commits/e1852b2879552465649535615531050aa65e6939 fixes a memory leak I introduced in https://github.com/sylikc/jpegview/pull/208 (my bad) and https://github.com/sylikc/jpegview/pull/213/commits/2ce3887476c5d5edae09731ac4916e8269e6b514 partially fixes https://github.com/sylikc/jpegview/issues/207.