### PR TITLE
Add scoop installation section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ scoop bucket add extras
 scoop install extras/jpegview-fork
 ```
 
-After installation, the configuration file is located at `C:\Users\<your-username>\scoop\persist\JPEGView-fork\JPEGView.ini`.
+After installation, the configuration file is located at `%HOMEPATH%\scoop\persist\JPEGView-fork\JPEGView.ini`.
 
 ## PortableApps
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ scoop bucket add extras
 scoop install extras/jpegview-fork
 ```
 
-After installation, the configuration file is located at `%HOMEPATH%\scoop\persist\JPEGView-fork\JPEGView.ini`.
+After installation, the configuration file is located at `%UserProfile%\scoop\persist\JPEGView-fork\JPEGView.ini`.
 
 ## System Requirements
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ Starting package install...
 Successfully installed
 ```
 
-### Scoop
+## PortableApps
+
+Another option is to use the official [JPEGView on PortableApps](https://portableapps.com/apps/graphics_pictures/jpegview_portable) package.  The PortableApps launcher preserves user settings in a separate directory from the extracted application directory.  This release is signed.
+
+## Scoop
 
 [Scoop](https://scoop.sh/) is a Windows command-line installer and manager for portable applications.
 
@@ -100,10 +104,6 @@ scoop install extras/jpegview-fork
 ```
 
 After installation, the configuration file is located at `%HOMEPATH%\scoop\persist\JPEGView-fork\JPEGView.ini`.
-
-## PortableApps
-
-Another option is to use the official [JPEGView on PortableApps](https://portableapps.com/apps/graphics_pictures/jpegview_portable) package.  The PortableApps launcher preserves user settings in a separate directory from the extracted application directory.  This release is signed.
 
 ## System Requirements
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Basic on-the-fly image processing is provided - allowing adjusting typical param
 * contrast
 * local under-exposure/over-exposure
 
-### Other Features:
+### Other Features
 
 * Small and fast, uses AVX2/SSE2 and up to 4 CPU cores
 * High quality resampling filter, preserving sharpness of images
@@ -87,6 +87,19 @@ Successfully verified installer hash
 Starting package install...
 Successfully installed
 ```
+
+### Scoop
+
+[Scoop](https://scoop.sh/) is a Windows command-line installer and manager for portable applications.
+
+To install with Scoop, run the following commands:
+
+```shell
+scoop bucket add extras
+scoop install extras/jpegview-fork
+```
+
+After installation, the configuration file is located at `C:\Users\<your-username>\scoop\persist\JPEGView-fork\JPEGView.ini`.
 
 ## PortableApps
 
@@ -146,7 +159,6 @@ See the [Localization wiki page](https://github.com/sylikc/jpegview/wiki/Localiz
 The JPEGView documentation is a little out of the date at the moment, but should still give a good summary of the features.
 
 This [readme.html](https://htmlpreview.github.io/?https://github.com/sylikc/jpegview/blob/master/src/JPEGView/Config/readme.html) is part of the JPEGView package.
-
 
 # Brief History
 


### PR DESCRIPTION
Adds a section to the README.md about installation with [scoop](https://scoop.sh).

The manifest file representing this project has been [merged](https://github.com/ScoopInstaller/Extras/pull/11544) to the scoop `extras` bucket as `jpegview-fork`, so as an installation method, it is ready to be published.

I have tested it to work with the commands proposed in this commit, and all good. These are also [the same commands offered by the index when searching for `jpegview-fork`](https://scoop.sh/#/apps?q=jpegview-fork).

For posterity, that file is located in the `extras` repo here: [https://github.com/ScoopInstaller/Extras/blob/master/bucket/jpegview-fork.json](https://github.com/ScoopInstaller/Extras/blob/master/bucket/jpegview-fork.json). It does have features that enable the automatic scanning of this project to find the latest release and self-update. If we do decide to change anything about configuration file management, this manifest may need to be updated accordingly because that stuff is hardcoded into it (stuff about persisting `JPEGview.ini`, etc.).

I also fixed up some minor typography things in other parts of the Readme.

As far as the scoop community goes, I think we will see a day when this project (`jpegview-fork`) supplants the original (`jpegview`) completely, and no longer need the `-fork` suffix. But right now, we need to wait for the cultural shift, and the best way to introduce that idea is to make incremental steps like this.

