### PR TITLE
optimize RGBA to BGRA conversion

### DIFF
--- a/src/JPEGView/HEIFWrapper.cpp
+++ b/src/JPEGView/HEIFWrapper.cpp
@@ -51,21 +51,16 @@ void * HeifReader::ReadImage(int &width,
 	}
 	std::vector<uint8_t> iccp = image.get_raw_color_profile();
 	void* transform = ICCProfileTransform::CreateTransform(iccp.data(), iccp.size(), ICCProfileTransform::FORMAT_RGBA);
-	uint8_t* p;
 	size_t i, j;
 	if (!ICCProfileTransform::DoTransform(transform, data, pPixelData, width, height, stride=stride)) {
-		memcpy(pPixelData, data, size);
-		unsigned char* o = pPixelData;
+		unsigned int* o = (unsigned int*)pPixelData;
 		for (i = 0; i < height; i++) {
-			p = data + i * stride;
+			unsigned int* p = (unsigned int*)(data + i * stride);
 			for (j = 0; j < width; j++) {
 				// RGBA -> BGRA conversion
-				o[0] = p[2];
-				o[1] = p[1];
-				o[2] = p[0];
-				o[3] = p[3];
-				p += nchannels;
-				o += nchannels;
+				*o = _rotr(_byteswap_ulong(*p), 8);
+				p++;
+				o++;
 			}
 		}
 	}

--- a/src/JPEGView/JXLWrapper.cpp
+++ b/src/JPEGView/JXLWrapper.cpp
@@ -207,10 +207,11 @@ void* JxlReader::ReadImage(int& width,
 	if (cache.transform == NULL)
 		cache.transform = ICCProfileTransform::CreateTransform(icc_profile.data(), icc_profile.size(), ICCProfileTransform::FORMAT_RGBA);
 	if (!ICCProfileTransform::DoTransform(cache.transform, pixels.data(), pPixelData, width, height)) {
-		memcpy(pPixelData, pixels.data(), size);
 		// RGBA -> BGRA conversion (with little-endian integers)
-		for (uint32_t* i = (uint32_t*)pPixelData; (uint8_t*)i < pPixelData + size; i++)
-			*i = ((*i & 0x00FF0000) >> 16) | ((*i & 0x0000FF00)) | ((*i & 0x000000FF) << 16) | ((*i & 0xFF000000));
+		uint32_t* data = (uint32_t*)pixels.data();
+		for (int i = 0; i * sizeof(uint32_t) < size; i++) {
+			((uint32_t*)pPixelData)[i] = _rotr(_byteswap_ulong(data[i]), 8);
+		}
 	}
 
 	// Copy Exif data into the format understood by CEXIFReader


### PR DESCRIPTION
Speed up RGBA -> BGRA conversion by ~25% for JXL and ~150% for HEIF.

Slow:  
`((value & 0x00FF0000) >> 16) | ((value & 0x000000FF) << 16) | (value & 0xFF00FF00);`  

Faster:  
`_rotr(value & 0x00FF00FF, 16) | (value & 0xFF00FF00);`  
`(((value >> 16) | (value << 16)) & 0x00FF00FF) | (value & 0xFF00FF00);`  
`((_byteswap_ulong(value) >> 8) & 0x00FF00FF) | (value & 0xFF00FF00);`  

Fastest:  
`_rotr(_byteswap_ulong(value), 8);`  
`_byteswap_ulong(_rotl(value, 8));`  

I also got rid of the unnecessary `memcpy`s.

For me this saves 50-100ms for large files.
