### PR TITLE
Show acquisition date from RAW metadata in window title

### DIFF
--- a/src/JPEGView/MainDlg.cpp
+++ b/src/JPEGView/MainDlg.cpp
@@ -34,6 +34,7 @@
 #include "ResizeFilter.h"
 #include "EXIFReader.h"
 #include "EXIFHelpers.h"
+#include "RawMetadata.h"
 #include "ProcessingThreadPool.h"
 #include "PaintMemDCMgr.h"
 #include "PanelMgr.h"
@@ -3233,8 +3234,11 @@ void CMainDlg::UpdateWindowTitle() {
 		sWindowText += Helpers::GetMultiframeIndex(m_pCurrentImage);
 		if (CSettingsProvider::This().ShowEXIFDateInTitle()) {
 			CEXIFReader* pEXIF = m_pCurrentImage->GetEXIFReader();
+			CRawMetadata* pRawMetadata = m_pCurrentImage->GetRawMetadata();
 			if (pEXIF != NULL && pEXIF->GetAcquisitionTime().wYear > 1600) {
 				sWindowText += " - " + Helpers::SystemTimeToString(pEXIF->GetAcquisitionTime());
+			} else if (pRawMetadata != NULL && pRawMetadata->GetAcquisitionTime().wYear > 1985) {
+				sWindowText += " - " + Helpers::SystemTimeToString(pRawMetadata->GetAcquisitionTime());
 			}
 		}
 		sWindowText += " - " + CString(JPEGVIEW_TITLE);


### PR DESCRIPTION
JPEGView shows the acquisition date in the window title if it's found in the EXIF data, but not if it's found in the RAW metadata.  
Example files: https://github.com/lclevy/canon_cr3/issues/30#issuecomment-1586193932