### PR TITLE
Fix AVIF detection

### DIFF
--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -75,22 +75,15 @@ static EImageFormat GetImageFormat(LPCTSTR sFileName) {
 	//	return IF_TIFF;
 
 	} else if (header[0] == 0x00 && header[1] == 0x00 && header[2] == 0x00 && memcmp(header+4, "ftyp", 4) == 0) {
-		if (memcmp(header + 8, "avif", 4) == 0 || memcmp(header + 8, "avis", 4) == 0)
-			return IF_AVIF;
-
 		// https://github.com/strukturag/libheif/issues/83
-		if (memcmp(header + 8, "heic", 4) == 0 ||
-			memcmp(header + 8, "heix", 4) == 0 ||
-			memcmp(header + 8, "hevc", 4) == 0 ||
-			memcmp(header + 8, "hevx", 4) == 0 ||
-			memcmp(header + 8, "heim", 4) == 0 ||
-			memcmp(header + 8, "heis", 4) == 0 ||
-			memcmp(header + 8, "hevm", 4) == 0 ||
-			memcmp(header + 8, "hevs", 4) == 0 ||
-			memcmp(header + 8, "mif1", 4) == 0 ||
-			memcmp(header + 8, "msf1", 4) == 0) {
+		// https://github.com/strukturag/libheif/blob/ce1e4586b6222588c5afcd60c7ba9caa86bcc58c/libheif/heif.h#L602-L805
+
+		// H265: heic, heix, hevc, hevx, heim, heis, hevm, hevs
+		if (header[8] == 'h' && header[9] == 'e')
 			return IF_HEIF;
-		}
+		// AV1: avif, avis
+		// Unspecified encoding: mif1, mif2, msf1, miaf, 1pic
+		return IF_AVIF; // try libavif, fallback to libheif
 	} else if (header[0] == 'q' && header[1] == 'o' && header[2] == 'i' && header[3] == 'f') {
 		return IF_QOI;
 	} else if (header[0] == '8' && header[1] == 'B' && header[2] == 'P' && header[3] == 'S') {


### PR DESCRIPTION
It's currently possible for AVIF files to be mistaken as HEIF when we read the file header. Major brands starting with "m" do not specify the encoding of the file, but we currently assume they're HEIFs. This means that animated AVIF files which use "msf1" as the major brand will be decoded with libheif, which doesn't support animation, and therefore either not render or appear static ([example](https://github.com/sylikc/jpegview/files/13343462/msf1.zip)). This also means that AVIF files without the major brand "avif" or "avis" will fail to be decoded if the user has the libavif and dav1d DLLs but not libheif.

Since we already use libheif as a fallback for libavif, we should just treat HEIF/AVIF files as AVIF if we can't determine their encoding from the header.

See [here](https://github.com/strukturag/libheif/blob/ce1e4586b6222588c5afcd60c7ba9caa86bcc58c/libheif/heif.h#L602-L805) for a list of major brands.