### PR TITLE
Ignore EXIF orientation for HEIF/AVIF

### DIFF
--- a/src/JPEGView/EXIFReader.cpp
+++ b/src/JPEGView/EXIFReader.cpp
@@ -299,8 +299,8 @@ CEXIFReader::CEXIFReader(void* pApp1Block, EImageFormat eImageFormat)
 
 	// image orientation
 	uint8* pTagOrientation = NULL;
-	// orientation tags must be ignored for JXL, they are taken care of by the decoder
-	if (eImageFormat != IF_JXL) {
+	// orientation tags must be ignored for JXL and HEIF/AVIF
+	if (eImageFormat != IF_JXL && eImageFormat != IF_HEIF && eImageFormat != IF_AVIF) {
 		pTagOrientation = FindTag(pIFD0, pLastIFD0, 0x112, bLittleEndian);
 	}
 	if (pTagOrientation != NULL) {


### PR DESCRIPTION
EXIF orientation should be ignored according to JXL and HEIF specs.  

Sources:  
[libjxl](https://github.com/libjxl/libjxl/blob/4451ce9fdd3780cc0ad5cf1fea529615a6d84f2d/doc/format_overview.md?plain=1#L62-L67)  
https://github.com/strukturag/libheif/issues/227#issuecomment-916176774  
https://github.com/AOMediaCodec/libavif/issues/996#issuecomment-1196157817  
https://zpl.fi/exif-orientation-in-different-formats/  

While testing this I found 2 issues:  
1. We don't support mirroring with the Orientation tag (see [0x112](https://exiftool.org/TagNames/EXIF.html)). [Relevant code](https://github.com/sylikc/jpegview/blob/57ac9bcf1b9154bc6650434a576d3fb85209d75f/src/JPEGView/JPEGImage.cpp#L1422-L1435)
2. libheif automatically rotates images based on the `irot` and `imir` boxes, but libavif doesn't. [example image](https://zpl.fi/exif-orientation-in-different-formats/Rot3Mir1-1x.avif) (fixed by #305)

Fixes #299