### PR TITLE
Implement AVIF transformations

### DIFF
--- a/src/JPEGView/AVIFWrapper.cpp
+++ b/src/JPEGView/AVIFWrapper.cpp
@@ -47,6 +47,7 @@ void* AvifReader::ReadImage(int& width,
 		memcpy(cache.data, buffer, sizebytes);
 		cache.decoder = avifDecoderCreate();
 		cache.decoder->maxThreads = nthreads;
+		cache.decoder->strictFlags = AVIF_STRICT_DISABLED;
 		result = avifDecoderSetIOMemory(cache.decoder, cache.data, sizebytes);
 		if (result != AVIF_RESULT_OK) {
 			DeleteCache();

--- a/src/JPEGView/AVIFWrapper.cpp
+++ b/src/JPEGView/AVIFWrapper.cpp
@@ -92,20 +92,6 @@ void* AvifReader::ReadImage(int& width,
 		DeleteCache();
 		return NULL;
 	}
-	avifRWData icc = cache.decoder->image->icc;
-	if (cache.transform == NULL)
-		cache.transform = ICCProfileTransform::CreateTransform(icc.data, icc.size, ICCProfileTransform::FORMAT_BGRA);
-	ICCProfileTransform::DoTransform(cache.transform, cache.rgb.pixels, cache.rgb.pixels, width, height);
-
-	avifRWData exif = cache.decoder->image->exif;
-	if (exif.size > 8 && exif.size < 65528 && exif.data != NULL) {
-		exif_chunk = malloc(exif.size + 10);
-		if (exif_chunk != NULL) {
-			memcpy(exif_chunk, "\xFF\xE1\0\0Exif\0\0", 10);
-			*((unsigned short*)exif_chunk + 1) = _byteswap_ushort(exif.size + 8);
-			memcpy((uint8_t*)exif_chunk + 10, exif.data, exif.size);
-		}
-	}
 
 	// Handle clap, irot and imir boxes
 	avifTransformFlags flags = cache.decoder->image->transformFlags;
@@ -143,6 +129,21 @@ void* AvifReader::ReadImage(int& width,
 		if (pixels != NULL) {
 			delete[] cache.rgb.pixels;
 			cache.rgb.pixels = (uint8_t*)pixels;
+		}
+	}
+
+	avifRWData icc = cache.decoder->image->icc;
+	if (cache.transform == NULL)
+		cache.transform = ICCProfileTransform::CreateTransform(icc.data, icc.size, ICCProfileTransform::FORMAT_BGRA);
+	ICCProfileTransform::DoTransform(cache.transform, cache.rgb.pixels, cache.rgb.pixels, width, height);
+
+	avifRWData exif = cache.decoder->image->exif;
+	if (exif.size > 8 && exif.size < 65528 && exif.data != NULL) {
+		exif_chunk = malloc(exif.size + 10);
+		if (exif_chunk != NULL) {
+			memcpy(exif_chunk, "\xFF\xE1\0\0Exif\0\0", 10);
+			*((unsigned short*)exif_chunk + 1) = _byteswap_ushort(exif.size + 8);
+			memcpy((uint8_t*)exif_chunk + 10, exif.data, exif.size);
 		}
 	}
 

--- a/src/JPEGView/BasicProcessing.cpp
+++ b/src/JPEGView/BasicProcessing.cpp
@@ -655,7 +655,6 @@ void* CBasicProcessing::Rotate32bpp(int nWidth, int nHeight, const void* pDIBPix
 }
 
 void* CBasicProcessing::Mirror32bpp(int nWidth, int nHeight, const void* pDIBPixels, bool bHorizontally) {
-	if (pDIBPixels == NULL) return NULL;
 	return bHorizontally ? CBasicProcessing::MirrorH32bpp(nWidth, nHeight, pDIBPixels) :
 		CBasicProcessing::MirrorV32bpp(nWidth, nHeight, pDIBPixels);
 }

--- a/src/JPEGView/BasicProcessing.cpp
+++ b/src/JPEGView/BasicProcessing.cpp
@@ -654,6 +654,12 @@ void* CBasicProcessing::Rotate32bpp(int nWidth, int nHeight, const void* pDIBPix
 	return pTarget;
 }
 
+void* CBasicProcessing::Mirror32bpp(int nWidth, int nHeight, const void* pDIBPixels, bool bHorizontally) {
+	if (pDIBPixels == NULL) return NULL;
+	return bHorizontally ? CBasicProcessing::MirrorH32bpp(nWidth, nHeight, pDIBPixels) :
+		CBasicProcessing::MirrorV32bpp(nWidth, nHeight, pDIBPixels);
+}
+
 void* CBasicProcessing::MirrorH32bpp(int nWidth, int nHeight, const void* pDIBPixels) {
 	uint32* pTarget = new(std::nothrow) uint32[nWidth * nHeight];
 	if (pTarget == NULL) return NULL;

--- a/src/JPEGView/BasicProcessing.h
+++ b/src/JPEGView/BasicProcessing.h
@@ -56,6 +56,9 @@ public:
 	// cases the return value is NULL
 	static void* Rotate32bpp(int nWidth, int nHeight, const void* pDIBPixels, int nRotationAngleCW);
 
+	// Mirror 32 bit DIB
+	static void* Mirror32bpp(int nWidth, int nHeight, const void* pDIBPixels, bool bHorizontally);
+
 	// Mirror 32 bit DIB horizontally
 	static void* MirrorH32bpp(int nWidth, int nHeight, const void* pDIBPixels);
 

--- a/src/JPEGView/JPEGImage.cpp
+++ b/src/JPEGView/JPEGImage.cpp
@@ -715,8 +715,7 @@ bool CJPEGImage::Mirror(bool bHorizontally) {
 	}
 
 	InvalidateAllCachedPixelData();
-	void* pNewOriginalPixels = bHorizontally ? CBasicProcessing::MirrorH32bpp(m_nOrigWidth, m_nOrigHeight, m_pOrigPixels) :
-		CBasicProcessing::MirrorV32bpp(m_nOrigWidth, m_nOrigHeight, m_pOrigPixels);
+	void* pNewOriginalPixels = CBasicProcessing::Mirror32bpp(m_nOrigWidth, m_nOrigHeight, m_pOrigPixels, bHorizontally);
 	if (pNewOriginalPixels == NULL) return false;
 	delete[] m_pOrigPixels;
 	m_pOrigPixels = pNewOriginalPixels;


### PR DESCRIPTION
HEIF files can contain `clap`, `irot` and `imir` boxes which indicate cropping, rotation and mirroring transformations respectively. libheif takes care of this for us, but libavif doesn't. Fortunately we can just use existing helper functions to do the transformations.

Test files:  
https://github.com/AOMediaCodec/av1-avif/tree/master/testFiles/Link-U *
https://git.zpl.fi/exif-orientation/tree/images (RotXMirY.avif files)  
https://github.com/chromium/chromium/tree/main/third_party/blink/web_tests/images/resources/avif (cropped images)  


\* Note that the cropped AVIFs here fail to decode with libavif due to the crop's non-integer Y offset. They then fall back to libheif, so they can't be used for testing this change. Chromium disables libavif's strict `clap` validation and just ignores the `clap` if it has non-zero offsets, so it displays the images uncropped but with the correct rotation and mirroring. Not sure if we should just copy their logic. See https://github.com/chromium/chromium/commit/3a13337543c1e7de6914f87cd6f02ab06751c572