### PR TITLE
Fix possible crash on displaying very large images

### DIFF
--- a/src/JPEGView/XMMImage.cpp
+++ b/src/JPEGView/XMMImage.cpp
@@ -18,7 +18,7 @@ CXMMImage::CXMMImage(int nWidth, int nHeight, int nFirstX, int nLastX, int nFirs
 
 	if (m_pMemory != NULL) {
 		int nSrcLineWidthPadded = Helpers::DoPadding(nWidth * nChannels, 4);
-		const uint8* pSrc = (uint8*)pDIB + nFirstY*nSrcLineWidthPadded + nFirstX*nChannels;
+		const uint8* pSrc = (uint8*)pDIB + (long long)nFirstY*(long long)nSrcLineWidthPadded + (long long)nFirstX*(long long)nChannels;
 		uint16* pDst = (unsigned short*) m_pMemory;
 		for (int j = 0; j < nSectionHeight; j++) {
 			if (nChannels == 4) {


### PR DESCRIPTION
`nFirstY`, `nSrcLineWidthPadded`, `nFirstX` and `nChannels` are type `int`; multiplying them, the result will internally be treated as `int` values again. For very large images, this can cause integer overflows, with the resulting negative values causing a wrong address in the `pSrc` pointer, leading to a crash. One possible fix is to cast those values to int64 (long long) before multiplication, as in the current PR does.
 (Strictly speaking, this fix is not neccessary for `nFirstX*nChannels`, since that ones' product can't grow that large, with `nChannels` being a single digit value...)

Alternatively, we could get away with just using `uint32` instead of `long long`, since none of the factors should ever be negative. It would allow for images up to 65535x65535 in size not triggering on overflow, which happens to be our size limit in `MaxImageDef.h`:
```
const unsigned int MAX_IMAGE_DIMENSION = 65535;
```

Btw, it might make sense to also change:
```
const unsigned int MAX_IMAGE_PIXELS = 1024 * 1024 * 500;
```
to
```
const unsigned int MAX_IMAGE_PIXELS = 65535 * 65535;
```