### PR TITLE
psd: properly skip image resource names

### DIFF
--- a/src/JPEGView/PSDWrapper.cpp
+++ b/src/JPEGView/PSDWrapper.cpp
@@ -191,8 +191,8 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 			unsigned short nResourceID = ReadUShortFromFile(hFile);
 
 			// Skip Pascal string (padded to be even length)
-			unsigned char nStringSize = ReadUCharFromFile(hFile) | 1;
-			SeekFile(hFile, nStringSize);
+			unsigned char nStringSize = ReadUCharFromFile(hFile);
+			SeekFile(hFile, nStringSize | 1);
 
 			// Resource size
 			unsigned int nResourceSize = ReadUIntFromFile(hFile);
@@ -438,7 +438,8 @@ CJPEGImage* PsdReader::ReadThumb(LPCTSTR strFileName, bool& bOutOfMemory)
 			unsigned short nResourceID = ReadUShortFromFile(hFile);
 
 			// Skip Pascal string (padded to be even length)
-			while (ReadUShortFromFile(hFile));
+			unsigned char nStringSize = ReadUCharFromFile(hFile);
+			SeekFile(hFile, nStringSize | 1);
 
 			// Resource size
 			unsigned int nResourceSize = ReadUIntFromFile(hFile);

--- a/src/JPEGView/PSDWrapper.cpp
+++ b/src/JPEGView/PSDWrapper.cpp
@@ -191,7 +191,8 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 			unsigned short nResourceID = ReadUShortFromFile(hFile);
 
 			// Skip Pascal string (padded to be even length)
-			while (ReadUShortFromFile(hFile));
+			unsigned char nStringSize = ReadUCharFromFile(hFile) | 1;
+			SeekFile(hFile, nStringSize);
 
 			// Resource size
 			unsigned int nResourceSize = ReadUIntFromFile(hFile);

--- a/src/JPEGView/PSDWrapper.cpp
+++ b/src/JPEGView/PSDWrapper.cpp
@@ -79,7 +79,7 @@ static inline unsigned short ReadUShortFromFile(HANDLE file) {
 }
 
 // Read and return an unsigned char from file
-static inline unsigned short ReadUCharFromFile(HANDLE file) {
+static inline unsigned char ReadUCharFromFile(HANDLE file) {
 	unsigned char val;
 	ReadFromFile(&val, file, 1);
 	return val;


### PR DESCRIPTION
The current way we skip image resource names is wrong, idk what I was thinking when I wrote it. Most PSDs don't store the names (they just use `00 00` as the string), which is why I didn't notice this before.

https://stackoverflow.com/questions/28519732/what-is-a-pascal-style-string