### PR TITLE
Fix CR3 detection

### DIFF
--- a/src/JPEGView/Helpers.cpp
+++ b/src/JPEGView/Helpers.cpp
@@ -767,7 +767,7 @@ EImageFormat GetImageFormat(LPCTSTR sFileName) {
 			return IF_JXL;
 		} else if (_tcsicmp(sEnding, _T("AVIF")) == 0) {
 			return IF_AVIF;
-		} else if (_tcsicmp(sEnding, _T("HEIF")) == 0 || _tcsicmp(sEnding, _T("HEIC")) == 0) {
+		} else if (_tcsicmp(sEnding, _T("HEIF")) == 0 || _tcsicmp(sEnding, _T("HEIC")) == 0 || _tcsicmp(sEnding, _T("HIF")) == 0) {
 			return IF_HEIF;
 		} else if (_tcsicmp(sEnding, _T("TGA")) == 0) {
 			return IF_TGA;


### PR DESCRIPTION
#261 broke CR3 detection. CR3 uses the HEIF container, so it gets detected as a HEIF before checking the file extension.

I added a check for the "crx " major brand and moved the unspecified encoding fallback after the file extension check. I moved TIFF detection here as well, which currently won't really do anything since it just goes to GDI+ anyway. I also added the `.HIF` extension used by newer Canon cameras (https://github.com/lclevy/canon_cr3/blob/master/heif.md)