### PR TITLE
Fix decoding K25 raw images

### DIFF
--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -997,6 +997,9 @@ void CImageLoadThread::ProcessReadRAWRequest(CRequest * request) {
 			if (fullsize == 2 || fullsize == 3) {
 				request->Image = RawReader::ReadImage(request->FileName, bOutOfMemory, fullsize == 2);
 			}
+			if (request->Image == NULL && fullsize == 2) {
+				request->Image = CReaderRAW::ReadRawImage(request->FileName, bOutOfMemory);
+			}
 			if (request->Image == NULL) {
 				request->Image = RawReader::ReadImage(request->FileName, bOutOfMemory, fullsize == 0 || fullsize == 3);
 			}
@@ -1004,10 +1007,12 @@ void CImageLoadThread::ProcessReadRAWRequest(CRequest * request) {
 			// libraw.dll not found or VC++ Runtime not installed
 		}
 		SetErrorMode(nPrevErrorMode);
+#else
+		fullsize = fullsize == 1;
 #endif
 
 		// Try with dcraw_mod
-		if (request->Image == NULL && fullsize != 1) {
+		if (request->Image == NULL && fullsize != 1 && fullsize != 2) {
 			request->Image = CReaderRAW::ReadRawImage(request->FileName, bOutOfMemory);
 		}
 	} catch (...) {

--- a/src/JPEGView/RAWWrapper.cpp
+++ b/src/JPEGView/RAWWrapper.cpp
@@ -20,8 +20,14 @@ CJPEGImage* RawReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory, bool b
 	
 	CJPEGImage* Image = NULL;
 	if (!bGetThumb) {
-		RawProcessor.get_mem_image_format(&width, &height, &colors, &bps);
 		RawProcessor.imgdata.params.output_bps = 8;
+
+		// Must unpack and process first to get accurate info
+		if (RawProcessor.unpack() != LIBRAW_SUCCESS || RawProcessor.dcraw_process() != LIBRAW_SUCCESS) {
+			return NULL;
+		}
+
+		RawProcessor.get_mem_image_format(&width, &height, &colors, &bps);
 
 		if (width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
 			return NULL;
@@ -29,10 +35,6 @@ CJPEGImage* RawReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory, bool b
 
 		if ((double)width * height > MAX_IMAGE_PIXELS) {
 			bOutOfMemory = true;
-			return NULL;
-		}
-
-		if (RawProcessor.unpack() != LIBRAW_SUCCESS || RawProcessor.dcraw_process() != LIBRAW_SUCCESS) {
 			return NULL;
 		}
 


### PR DESCRIPTION
RawProcessor might not have an accurate number of colors before the RAW image is unpacked and processed. For the sample images we currently detect 4 colors instead of 3, so the decoded image looks corrupt. The `unpack` method already has [size checks similar to ours](https://github.com/LibRaw/LibRaw/blob/0.21.1/src/decoders/unpack.cpp#L52-L77), so memory shouldn't be an issue if we get the info after processing.

K25 images use [PPM](https://en.wikipedia.org/wiki/Netpbm#Description) thumbnails, so `RawReader::ReadImage` can't parse them. If `DisplayFullsizeRaw=2` then we will show the full image, even though dcraw_mod would be able to get thumbnail. I changed this so we try dcraw before getting the fullsize.

Samples: https://sembiance.com/fileFormatSamples/image/kodakK25/