### PR TITLE
psd: use byte counts for scan lines

### DIFF
--- a/src/JPEGView/PSDWrapper.cpp
+++ b/src/JPEGView/PSDWrapper.cpp
@@ -300,6 +300,8 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 		if (nCompressionMethod == COMPRESSION_RLE) {
 			// Skip byte counts for scanlines
 			p += nHeight * nRealChannels * 2;
+			ThrowIf(p >= (unsigned char*)pBuffer + nImageDataSize);
+			unsigned char* pOffset = p;
 			for (unsigned channel = 0; channel < nChannels; channel++) {
 				unsigned rchannel;
 				if (nColorMode == MODE_Lab) {
@@ -308,9 +310,14 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 					rchannel = (-channel - 2) % nChannels;
 				}
 				for (unsigned row = 0; row < nHeight; row++) {
+					pOffset += _byteswap_ushort(*(unsigned short *)(pBuffer + (channel * nHeight + row) * 2));
+					p = pOffset;
+
 					for (unsigned count = 0; count < nWidth; ) {
 						unsigned char c;
-						ThrowIf(p >= (unsigned char*)pBuffer + nImageDataSize);
+						if (p >= (unsigned char*)pBuffer + nImageDataSize) {
+							break;
+						};
 						c = *p;
 						p += 1;
 

--- a/src/JPEGView/PSDWrapper.cpp
+++ b/src/JPEGView/PSDWrapper.cpp
@@ -349,6 +349,13 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 					}
 
 					pOffset += _byteswap_ushort(*(unsigned short*)(pBuffer + (channel * nHeight + row) * 2));
+#ifdef DEBUG
+					if (p != pOffset) {
+						WCHAR buf[100];
+						swprintf(buf, _T("Misaligned scan line bytes (%+d) for channel %d row %d\n"), p - pOffset, channel, row);
+						::OutputDebugString(buf);
+					}
+#endif
 				}
 			}
 		} else { // No compression

--- a/src/JPEGView/PSDWrapper.cpp
+++ b/src/JPEGView/PSDWrapper.cpp
@@ -135,7 +135,7 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 		if ((double)nHeight * nWidth > MAX_IMAGE_PIXELS) {
 			bOutOfMemory = true;
 		}
-		ThrowIf(bOutOfMemory || nHeight > MAX_IMAGE_DIMENSION || nWidth > MAX_IMAGE_DIMENSION);
+		ThrowIf(bOutOfMemory || max(nHeight, nWidth) > MAX_IMAGE_DIMENSION || !min(nHeight, nWidth));
 
 		// PSD can have bit depths of 1, 2, 4, 8, 16, 32
 		unsigned short nBitDepth = ReadUShortFromFile(hFile);

--- a/src/JPEGView/PSDWrapper.cpp
+++ b/src/JPEGView/PSDWrapper.cpp
@@ -300,7 +300,6 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 		if (nCompressionMethod == COMPRESSION_RLE) {
 			// Skip byte counts for scanlines
 			p += nHeight * nRealChannels * 2;
-			ThrowIf(p >= (unsigned char*)pBuffer + nImageDataSize);
 			unsigned char* pOffset = p;
 			for (unsigned channel = 0; channel < nChannels; channel++) {
 				unsigned rchannel;
@@ -310,14 +309,11 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 					rchannel = (-channel - 2) % nChannels;
 				}
 				for (unsigned row = 0; row < nHeight; row++) {
-					pOffset += _byteswap_ushort(*(unsigned short *)(pBuffer + (channel * nHeight + row) * 2));
 					p = pOffset;
 
 					for (unsigned count = 0; count < nWidth; ) {
 						unsigned char c;
-						if (p >= (unsigned char*)pBuffer + nImageDataSize) {
-							break;
-						};
+						ThrowIf(p >= (unsigned char*)pBuffer + nImageDataSize);
 						c = *p;
 						p += 1;
 
@@ -351,6 +347,8 @@ CJPEGImage* PsdReader::ReadImage(LPCTSTR strFileName, bool& bOutOfMemory)
 
 						count += c;
 					}
+
+					pOffset += _byteswap_ushort(*(unsigned short*)(pBuffer + (channel * nHeight + row) * 2));
 				}
 			}
 		} else { // No compression


### PR DESCRIPTION
Some PSDs rely on [the byte counts for each scan line](https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1054855) to be decoded correctly. ImageMagick seems to add a pad byte to each row in some cases when exporting to PSD. [Example](https://github.com/user-attachments/files/15812447/psd.scan.line.bytes.imagemagick.zip)

Also, "Desktop2.psd" from https://github.com/ImageMagick/ImageMagick/issues/1962 overshoots by 4 bytes on row 520 of the red plane. It fails to decode unless we use the byte counts.