### PR TITLE
try to use WIC for large TIFF files

### DIFF
--- a/src/JPEGView/ImageLoadThread.cpp
+++ b/src/JPEGView/ImageLoadThread.cpp
@@ -1057,12 +1057,16 @@ void CImageLoadThread::ProcessReadGDIPlusRequest(CRequest * request) {
 	bool isOutOfMemory, isAnimatedGIF;
 	request->Image = ConvertGDIPlusBitmapToJPEGImage(pBitmap, request->FrameIndex, NULL, 0, isOutOfMemory, isAnimatedGIF);
 	request->OutOfMemory = request->Image == NULL && isOutOfMemory;
+	if (request->OutOfMemory && GetBitmapFormat(pBitmap) == IF_TIFF) {
+		DeleteCachedGDIBitmap();
+		return ProcessReadWICRequest(request);
+	}
 	if (!isAnimatedGIF) {
 		DeleteCachedGDIBitmap();
 	}
 }
 
-static unsigned char* alloc(int sizeInBytes) {
+static unsigned char* alloc(size_t sizeInBytes) {
 	return new(std::nothrow) unsigned char[sizeInBytes];
 }
 
@@ -1070,7 +1074,7 @@ static void dealloc(unsigned char* buffer) {
 	delete[] buffer;
 }
 
-typedef unsigned char* Allocator(int sizeInBytes);
+typedef unsigned char* Allocator(size_t sizeInBytes);
 typedef void Deallocator(unsigned char* buffer);
 
 __declspec(dllimport) unsigned char* __stdcall LoadImageWithWIC(LPCWSTR fileName, Allocator* allocator, Deallocator* deallocator,

--- a/src/WICLoader/MaxImageDef.h
+++ b/src/WICLoader/MaxImageDef.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifdef _WIN64
-const unsigned int MAX_IMAGE_PIXELS = 1024 * 1024 * 300;
+const unsigned int MAX_IMAGE_PIXELS = 65535 * 65535;
 #else
 const unsigned int MAX_IMAGE_PIXELS = 1024 * 1024 * 100;
 #endif

--- a/src/WICLoader/WICLoader.cpp
+++ b/src/WICLoader/WICLoader.cpp
@@ -25,7 +25,7 @@
 // forward declaration
 static HRESULT CopyWICBitmapToBuffer(IWICBitmapSource *piBitmapSource, byte* pBuffer);
 
-typedef byte* Allocator(int sizeInBytes);
+typedef byte* Allocator(size_t sizeInBytes);
 typedef void Deallocator(byte* buffer);
 
 // Checks if WIC is installed by asking for the WIC imaging factory.
@@ -65,7 +65,7 @@ __declspec(dllexport) byte* __stdcall LoadImageWithWIC(LPCWSTR fileName, Allocat
 			piBitmapFrame->GetSize(width, height);
 			if (*width <= MAX_IMAGE_DIMENSION && *height <= MAX_IMAGE_DIMENSION) {
 				if ((double)*width * *height <= MAX_IMAGE_PIXELS) {
-					bitmapBuffer = allocator(*width * *height * 4);
+					bitmapBuffer = allocator((size_t)*width * *height * 4);
 					if (bitmapBuffer != NULL) {
 						hr = CopyWICBitmapToBuffer(piBitmapFrame, bitmapBuffer);
 						if (!SUCCEEDED(hr)) {


### PR DESCRIPTION
Support TIFF files with `> INT_MAX/4` pixels using Windows Imaging Component.

Sample TIFF here: https://hubblesite.org/contents/media/images/2019/17/4492-Image.html